### PR TITLE
Change checkbox style at the extensions + local pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "permissions": ["activeTab", "declarativeContent"],
   "content_scripts": [{
     "js": ["content.js"],
-    "matches": ["http://*/*", "https://*/*"]
+    "matches": ["<all_urls>"]
   }],
   "icons": {
     "16": "images/icon-16.png",


### PR DESCRIPTION
https://developer.chrome.com/extensions/match_patterns
`"<all_urls>":` matches any URL that starts with a permitted scheme (http:, https:, file:, ftp:, or chrome-extension:).