### PR TITLE
Fix for issue #5 with iframes on some websites

### DIFF
--- a/content.js
+++ b/content.js
@@ -2,19 +2,13 @@
 
 'use strict';
 
-// Guard the DOM for async rendering
-// See: https://github.com/hansemannn/chrome-mojave-checkbox-extension/issues/3
+const NEW_ZOOM = 1.0000001;
+const elements = [document.body, ...Array.from(document.getElementsByTagName('iframe'))];
 
-var NEW_ZOOM = 1.0000001;
-
-var objectsToZoom = [document.body];
-var objectsToZoom = objectsToZoom.concat(Array.from(document.getElementsByTagName("iframe"))); // Get all the iframes
-
-for (var i=0; i<objectsToZoom.length; i++) {
-    if (objectsToZoom[i] != null) {
-        if (objectsToZoom[i].tagName == "IFRAME") {
-	    objectsToZoom[i] = objectsToZoom[i].contentDocument.body; // get the body element of the iframe
-        }
-        objectsToZoom[i].style.zoom = NEW_ZOOM;
+elements.forEach(element => {
+    if (element === null) return;
+    if (element.tagName.toLowerCase() === 'iframe' && element.contentDocument !== null) {
+        element = element.contentDocument.body;
     }
-}
+    element.style.zoom = NEW_ZOOM;
+});

--- a/content.js
+++ b/content.js
@@ -4,6 +4,18 @@
 
 // Guard the DOM for async rendering
 // See: https://github.com/hansemannn/chrome-mojave-checkbox-extension/issues/3
-if (document.body !== null) {
-    document.body.style.zoom = 1.0000001;
+
+var NEW_ZOOM = 1.0000001;
+
+var objectsToZoom = [document.body];
+var objectsToZoom = objectsToZoom.concat(Array.from(document.getElementsByTagName("iframe"))); // Get all the iframes
+
+for (var i=0; i<objectsToZoom.length; i++) {
+    // console.log(objectsToZoom[i]);
+    if (objectsToZoom[i].tagName == "IFRAME") {
+	objectsToZoom[i] = objectsToZoom[i].contentDocument.body; // get the body element of the iframe
+    }
+    if (objectsToZoom[i] != null) {
+        objectsToZoom[i].style.zoom = NEW_ZOOM;
+    }
 }

--- a/content.js
+++ b/content.js
@@ -11,11 +11,10 @@ var objectsToZoom = [document.body];
 var objectsToZoom = objectsToZoom.concat(Array.from(document.getElementsByTagName("iframe"))); // Get all the iframes
 
 for (var i=0; i<objectsToZoom.length; i++) {
-    // console.log(objectsToZoom[i]);
-    if (objectsToZoom[i].tagName == "IFRAME") {
-	objectsToZoom[i] = objectsToZoom[i].contentDocument.body; // get the body element of the iframe
-    }
     if (objectsToZoom[i] != null) {
+        if (objectsToZoom[i].tagName == "IFRAME") {
+	    objectsToZoom[i] = objectsToZoom[i].contentDocument.body; // get the body element of the iframe
+        }
         objectsToZoom[i].style.zoom = NEW_ZOOM;
     }
 }

--- a/content.js~
+++ b/content.js~
@@ -1,9 +1,0 @@
-// Copyright 2018 Hans Knöchel. No rights reserved, do what you want with this!
-
-'use strict';
-
-// Guard the DOM for async rendering
-// See: https://github.com/hansemannn/chrome-mojave-checkbox-extension/issues/3
-if (document.body !== null) {
-    document.body.style.zoom = 1.0000001;
-}

--- a/content.js~
+++ b/content.js~
@@ -1,0 +1,9 @@
+// Copyright 2018 Hans Knöchel. No rights reserved, do what you want with this!
+
+'use strict';
+
+// Guard the DOM for async rendering
+// See: https://github.com/hansemannn/chrome-mojave-checkbox-extension/issues/3
+if (document.body !== null) {
+    document.body.style.zoom = 1.0000001;
+}


### PR DESCRIPTION
The checkboxes within iframes on w3schools (e.g. https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_input_checked) were not rendering. This pull request fixes this.

Performance is poor on some webpages unfortunatly.